### PR TITLE
Fix boot loop on M5Stack Core

### DIFF
--- a/M5Stack_CW_Trainer/Mode.cpp
+++ b/M5Stack_CW_Trainer/Mode.cpp
@@ -14,7 +14,7 @@ CTRL_MODE_T MODE_getCurrentMode(void) {
   return m_CtrlMode;
 }
 
-CTRL_MODE_T MODE_setCurrentMode(CTRL_MODE_T ctrlMode) {
+void MODE_setCurrentMode(CTRL_MODE_T ctrlMode) {
   m_CtrlMode = ctrlMode;
 }
 

--- a/M5Stack_CW_Trainer/Mode.h
+++ b/M5Stack_CW_Trainer/Mode.h
@@ -18,7 +18,7 @@ typedef enum INPUT_METHOD {
 } INPUT_METHOD_T;
 
 CTRL_MODE_T MODE_getCurrentMode(void);
-CTRL_MODE_T MODE_setCurrentMode(CTRL_MODE_T ctrlMode);
+void MODE_setCurrentMode(CTRL_MODE_T ctrlMode);
 
 void MODE_setJpMode(void);
 void MODE_setEnglishMode(void);


### PR DESCRIPTION
Fix boot loop on M5Stack Core:

Fixed return type on MODE_setInputMethod.